### PR TITLE
Specify relative build path in xcodebuild arguments

### DIFF
--- a/makefile
+++ b/makefile
@@ -22,7 +22,8 @@
 include $(CURDIR)/makefile.cfg
 
 IPA_URL      = $(BASE_URL)/$(APP).ipa
-BUILD_PATH   = $(shell pwd)/Build
+BUILD_DIR    = Build
+BUILD_PATH   = $(shell pwd)/$(BUILD_DIR)
 PAYLOAD_PATH = $(BUILD_PATH)/Payload
 UPLOAD_PATH  = $(BUILD_PATH)/Upload
 INFO_FILE    = $(BUILD_PATH)/Products/$(CONFIG)-iphoneos/$(APP).app/Info.plist
@@ -100,11 +101,11 @@ default: clean build package html
 .PHONY: clean
 clean:
 	@echo "${INFO_CLR}>> Cleaning $(APP)...${RESTORE_CLR}${RESULT_CLR}"
-	@xcodebuild -sdk iphoneos -workspace "$(WORKSPACE).xcworkspace" -scheme "$(SCHEME)" -configuration "$(CONFIG)" -jobs 2 clean | tail -n 2 | cat && printf "${RESET_CLR}" && rm -rf Build
+	@xcodebuild -sdk iphoneos -workspace "$(WORKSPACE).xcworkspace" -scheme "$(SCHEME)" -configuration "$(CONFIG)" -jobs 2 clean | tail -n 2 | cat && printf "${RESET_CLR}" && rm -rf $(BUILD_DIR)
 
 build:
 	@echo "${INFO_CLR}>> Building $(APP)...${RESTORE_CLR}${RESULT_CLR}"
-	@xcodebuild -sdk iphoneos -workspace "$(WORKSPACE).xcworkspace" -scheme "$(SCHEME)" -configuration "$(CONFIG)" -jobs 6 build | tail -n 2 | cat && printf "${RESET_CLR}"
+	@xcodebuild -sdk iphoneos -workspace "$(WORKSPACE).xcworkspace" -scheme "$(SCHEME)" -configuration "$(CONFIG)" SYMROOT="$(BUILD_DIR)/Products" -jobs 6 build | tail -n 2 | cat && printf "${RESET_CLR}"
 
 show_settings:
 	@xcodebuild -sdk iphoneos -workspace "$(WORKSPACE).xcworkspace" -scheme "$(SCHEME)" -configuration "$(CONFIG)" -showBuildSettings 2>/dev/null | grep "$(SECOND_ARG)"

--- a/makefile
+++ b/makefile
@@ -22,7 +22,6 @@
 include $(CURDIR)/makefile.cfg
 
 IPA_URL      = $(BASE_URL)/$(APP).ipa
-ICON_NAME    = Icon@2x.png
 BUILD_PATH   = $(shell pwd)/Build
 PAYLOAD_PATH = $(BUILD_PATH)/Payload
 UPLOAD_PATH  = $(BUILD_PATH)/Upload

--- a/makefile
+++ b/makefile
@@ -22,8 +22,7 @@
 include $(CURDIR)/makefile.cfg
 
 IPA_URL      = $(BASE_URL)/$(APP).ipa
-BUILD_DIR    = Build
-BUILD_PATH   = $(shell pwd)/$(BUILD_DIR)
+BUILD_PATH   = $(shell pwd)/Build
 PAYLOAD_PATH = $(BUILD_PATH)/Payload
 UPLOAD_PATH  = $(BUILD_PATH)/Upload
 INFO_FILE    = $(BUILD_PATH)/Products/$(CONFIG)-iphoneos/$(APP).app/Info.plist
@@ -101,11 +100,11 @@ default: clean build package html
 .PHONY: clean
 clean:
 	@echo "${INFO_CLR}>> Cleaning $(APP)...${RESTORE_CLR}${RESULT_CLR}"
-	@xcodebuild -sdk iphoneos -workspace "$(WORKSPACE).xcworkspace" -scheme "$(SCHEME)" -configuration "$(CONFIG)" -jobs 2 clean | tail -n 2 | cat && printf "${RESET_CLR}" && rm -rf $(BUILD_DIR)
+	@xcodebuild -sdk iphoneos -workspace "$(WORKSPACE).xcworkspace" -scheme "$(SCHEME)" -configuration "$(CONFIG)" -jobs 2 clean | tail -n 2 | cat && printf "${RESET_CLR}" && rm -rf "$(BUILD_PATH)"
 
 build:
 	@echo "${INFO_CLR}>> Building $(APP)...${RESTORE_CLR}${RESULT_CLR}"
-	@xcodebuild -sdk iphoneos -workspace "$(WORKSPACE).xcworkspace" -scheme "$(SCHEME)" -configuration "$(CONFIG)" SYMROOT="$(BUILD_DIR)/Products" -jobs 6 build | tail -n 2 | cat && printf "${RESET_CLR}"
+	@xcodebuild -sdk iphoneos -workspace "$(WORKSPACE).xcworkspace" -scheme "$(SCHEME)" -configuration "$(CONFIG)" SYMROOT="$(BUILD_PATH)/Products" -jobs 6 build | tail -n 2 | cat && printf "${RESET_CLR}"
 
 show_settings:
 	@xcodebuild -sdk iphoneos -workspace "$(WORKSPACE).xcworkspace" -scheme "$(SCHEME)" -configuration "$(CONFIG)" -showBuildSettings 2>/dev/null | grep "$(SECOND_ARG)"

--- a/makefile.cfg
+++ b/makefile.cfg
@@ -2,6 +2,7 @@ APP          = APP_NAME
 WORKSPACE    = WORKSPACE_NAME
 CONFIG       = InHouse
 SCHEME       = APP_INHOUSE
+ICON_NAME    = Icon@2x.png
 
 # iMessage addresses list seperated with white space
 IMSG_LIST    = a_imessage_email@mac.com +86.18621800000 another_email@me.com


### PR DESCRIPTION
1. Specify a relative build path in xcodebuild arguments, so there is no need to change Xcode's default build path settings.
2. Move ICON_NAME definition to makefile.cfg because projects may not use the default icon name.
